### PR TITLE
refactor: use thiserror to replace failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,4 @@ edition = "2018"
 travis-ci = { repository = "aesedepece/limits-rs" }
 
 [dependencies]
-failure = "0.1.6"
-failure_derive = "0.1.6"
+thiserror = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,7 @@
 //!
 //! Support for other operating systems and platforms may be added on demand.
 
-#[macro_use]
-extern crate failure_derive;
+use thiserror::Error;
 
 // Support for GNU/Linux
 #[cfg(target_os = "linux")]
@@ -24,12 +23,12 @@ pub use crate::default::*;
 
 /// All methods that can fail in this crate should return `Result<_, Error>`. That is, one of the
 /// variants herein.
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum Error {
-    #[fail(display = "Unsupported OS. Could not get process limits.")]
+    #[error("Unsupported OS. Could not get process limits.")]
     UnsupportedOS,
-    #[fail(display = "Proc file not found at `{}`: {}", _0, _1)]
-    ProcFileNotFound(String, #[cause] std::io::Error),
+    #[error("Proc file not found at `{}`: {}", .0, .1)]
+    ProcFileNotFound(String, #[source] std::io::Error),
 }
 
 /// Get the limits for the process in which we are running (our own process id).


### PR DESCRIPTION
[thiserror](https://crates.io/crates/thiserror) provides a convenient derive macro for the standard library's [std::error::Error](https://doc.rust-lang.org/std/error/trait.Error.html) trait.